### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install the Compas Toolkit, follow these steps:
 First, clone the GitHub repository:
 
 ```bash
-$ git clone https://github.com/NLeSC-COMPAS/compas-toolkit
+$ git clone --recurse-submodules https://github.com/NLeSC-COMPAS/compas-toolkit
 ```
 
 ### Compiling the C++ code


### PR DESCRIPTION
The COMPAS toolkit depends on several other repositories that need to get cloned as well. The --recurse-submodules takes care of this.